### PR TITLE
fix: resolve open issues and add clase-7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/node_modules
 **/package-lock.json
+**/.env

--- a/clase-6/client/index.html
+++ b/clase-6/client/index.html
@@ -9,23 +9,18 @@
   <script type="module">
     import { io } from 'https://cdn.socket.io/4.3.2/socket.io.esm.min.js'
 
-    const getUsername = async () => {
+    const getUsername = () => {
       const username = localStorage.getItem('username')
-      if (username) {
-        console.log(`User existed ${username}`)
-        return username
-      }
+      if (username) return username
 
-      const res = await fetch('https://random-data-api.com/api/users/random_user')
-      const { username: randomUsername } = await res.json()
-
+      const randomUsername = `user_${Math.random().toString(36).slice(2, 8)}`
       localStorage.setItem('username', randomUsername)
       return randomUsername
     }
 
     const socket = io({
       auth: {
-        username: await getUsername(),
+        username: getUsername(),
         serverOffset: 0
       }
     })

--- a/clase-7/.gitignore
+++ b/clase-7/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+db

--- a/clase-7/config.js
+++ b/clase-7/config.js
@@ -1,0 +1,5 @@
+export const {
+  PORT = 3000,
+  SALT_ROUND = 10,
+  SECRET_JWT_KEY = 'your-secret-key-here'
+} = process.env

--- a/clase-7/index.js
+++ b/clase-7/index.js
@@ -1,0 +1,76 @@
+import express from 'express'
+import { PORT, SECRET_JWT_KEY } from './config.js'
+import cookieParser from 'cookie-parser'
+import jwt from 'jsonwebtoken'
+import { UserRepository } from './user-repository.js'
+
+const app = express()
+
+app.set('view engine', 'ejs')
+
+app.use(express.json())
+app.use(cookieParser())
+
+app.use((req, res, next) => {
+  const token = req.cookies.access_token
+  req.session = { user: null }
+
+  try {
+    const data = jwt.verify(token, SECRET_JWT_KEY)
+    req.session.user = data
+  } catch {}
+
+  next()
+})
+
+app.get('/', (req, res) => {
+  const { user } = req.session
+  res.render('index', user)
+})
+
+app.post('/login', async (req, res) => {
+  const { username, password } = req.body
+  try {
+    const user = await UserRepository.login({ username, password })
+    const token = jwt.sign(
+      { id: user._id, username: user.username },
+      SECRET_JWT_KEY,
+      { expiresIn: '1h' }
+    )
+    res
+      .cookie('access_token', token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        maxAge: 1000 * 60 * 60
+      })
+      .status(200)
+      .json({ user })
+  } catch (error) {
+    res.status(401).json({ error: error.message })
+  }
+})
+
+app.post('/register', async (req, res) => {
+  const { username, password } = req.body
+  try {
+    const id = await UserRepository.create({ username, password })
+    res.status(201).json({ id })
+  } catch (error) {
+    res.status(400).json({ error: error.message })
+  }
+})
+
+app.post('/logout', (req, res) => {
+  res.clearCookie('access_token').json({ message: 'Logout successful' })
+})
+
+app.get('/protected', (req, res) => {
+  const { user } = req.session
+  if (!user) return res.status(403).send('Access not authorized')
+  res.render('protected', user)
+})
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`)
+})

--- a/clase-7/package.json
+++ b/clase-7/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "clase-7",
+  "version": "1.0.0",
+  "description": "JWT auth with Node.js and Express",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch index.js",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.7",
+    "db-local": "^3.1.0",
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "standard": "^17.1.2"
+  },
+  "eslintConfig": {
+    "extends": "standard"
+  }
+}

--- a/clase-7/user-repository.js
+++ b/clase-7/user-repository.js
@@ -1,0 +1,55 @@
+import DBLocal from 'db-local'
+import crypto from 'node:crypto'
+import bcrypt from 'bcrypt'
+import { SALT_ROUND } from './config.js'
+
+const { Schema } = new DBLocal({ path: './db' })
+
+const User = Schema('User', {
+  _id: { type: String, required: true },
+  username: { type: String, required: true },
+  password: { type: String, required: true }
+})
+
+export class UserRepository {
+  static async create ({ username, password }) {
+    Validation.username(username)
+    Validation.password(password)
+
+    const existingUser = User.findOne({ username })
+    if (existingUser) throw new Error(`The username "${username}" is already taken`)
+
+    const _id = crypto.randomUUID()
+    const hashedPassword = await bcrypt.hash(password, SALT_ROUND)
+
+    User.create({ _id, username, password: hashedPassword }).save()
+
+    return _id
+  }
+
+  static async login ({ username, password }) {
+    Validation.username(username)
+    Validation.password(password)
+
+    const user = User.findOne({ username })
+    if (!user) throw new Error('User not found')
+
+    const isValid = await bcrypt.compare(password, user.password)
+    if (!isValid) throw new Error('Invalid password')
+
+    const { password: _, ...publicUser } = user
+    return publicUser
+  }
+}
+
+class Validation {
+  static username (username) {
+    if (typeof username !== 'string') throw new Error('Username must be a string')
+    if (username.length < 3) throw new Error('Username must be at least 3 characters long')
+  }
+
+  static password (password) {
+    if (typeof password !== 'string') throw new Error('Password must be a string')
+    if (password.length < 6) throw new Error('Password must be at least 6 characters long')
+  }
+}

--- a/clase-7/views/index.ejs
+++ b/clase-7/views/index.ejs
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login y Registro</title>
+  <style>
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      background-color: #f5f5f5;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+    }
+
+    .container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .form-container {
+      display: flex;
+      flex-direction: column;
+      padding: 20px;
+      margin: 10px;
+      border-radius: 8px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      background-color: #fff;
+      width: 300px;
+    }
+
+    form h2 {
+      margin-bottom: 20px;
+      font-size: 24px;
+      text-align: center;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 5px;
+      font-weight: bold;
+    }
+
+    input {
+      width: 100%;
+      padding: 10px;
+      margin-bottom: 20px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+
+    button {
+      width: 100%;
+      padding: 10px;
+      background-color: #28a745;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 16px;
+    }
+
+    button:hover {
+      background-color: #218838;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <% if (typeof username !== 'undefined') { %>
+      <div class="form-container">
+        <h2 style="margin: 0; text-align: center;">Hola, <%= username %>!</h2>
+        <p>Estás en el panel de administración</p>
+        <button id="close-session">Cerrar sesión</button>
+      </div>
+    <% } %>
+
+    <% if (typeof username === 'undefined') { %>
+      <div class="form-container">
+        <form id="login-form">
+          <h2>Login</h2>
+          <label for="login-username">Username</label>
+          <input id="login-username" name="username" required>
+
+          <label for="login-password">Password</label>
+          <input type="password" id="login-password" name="password" required>
+
+          <button type="submit">Login</button>
+          <span>&nbsp;</span>
+        </form>
+      </div>
+
+      <div class="form-container">
+        <form id="register-form">
+          <h2>Register</h2>
+          <label for="register-username">Username</label>
+          <input id="register-username" name="username" required>
+
+          <label for="register-password">Password</label>
+          <input type="password" id="register-password" name="password" required>
+
+          <label for="register-confirm-password">Confirm password</label>
+          <input type="password" id="register-confirm-password" name="password" required>
+
+          <button type="submit">Register</button>
+          <span>&nbsp;</span>
+        </form>
+      </div>
+    <% } %>
+  </div>
+
+  <script>
+    const $ = el => document.querySelector(el)
+
+    const $loginForm = $('#login-form')
+    const $loginSpan = $('#login-form span')
+
+    const $registerForm = $('#register-form')
+    const $registerSpan = $('#register-form span')
+
+    const $logoutButton = $('#close-session')
+
+    $loginForm?.addEventListener('submit', e => {
+      e.preventDefault()
+      const username = $('#login-username').value
+      const password = $('#login-password').value
+
+      fetch('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      }).then(res => {
+        if (res.ok) {
+          $loginSpan.innerText = 'Sesión iniciada. Entrando...'
+          $loginSpan.style.color = 'green'
+          setTimeout(() => { window.location.href = '/protected' }, 1500)
+        } else {
+          $loginSpan.innerText = 'Error al iniciar sesión'
+          $loginSpan.style.color = 'red'
+        }
+      })
+    })
+
+    $registerForm?.addEventListener('submit', e => {
+      e.preventDefault()
+      const username = $('#register-username').value
+      const password = $('#register-password').value
+      const confirmPassword = $('#register-confirm-password').value
+
+      if (password !== confirmPassword) {
+        alert('Las contraseñas no coinciden')
+        return
+      }
+
+      fetch('/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      }).then(res => {
+        if (res.ok) {
+          $registerSpan.innerText = 'Usuario registrado. Iniciando sesión...'
+          $registerSpan.style.color = 'green'
+          setTimeout(() => {
+            fetch('/login', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ username, password })
+            }).then(res => {
+              if (res.ok) {
+                window.location.href = '/protected'
+              } else {
+                window.location.href = '/'
+              }
+            })
+          }, 1500)
+        } else {
+          res.json().then(data => {
+            $registerSpan.innerText = data.error ?? 'Error al registrar usuario'
+            $registerSpan.style.color = 'red'
+          })
+        }
+      })
+    })
+
+    $logoutButton?.addEventListener('click', () => {
+      fetch('/logout', { method: 'POST' }).then(() => {
+        window.location.href = '/'
+      })
+    })
+  </script>
+</body>
+</html>

--- a/clase-7/views/protected.ejs
+++ b/clase-7/views/protected.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contenido protegido</title>
+</head>
+<body>
+  <h1>Hola, <%= username %></h1>
+  <h2>Este contenido está protegido</h2>
+</body>
+</html>


### PR DESCRIPTION
Resuelve todas las issues abiertas:

- **# A6ade `**/.env` al `.gitignore` ra**  para ignorar archivos `.env` en todos los subdirectorios
- **# Reemplaza la API `random-data-api.com` (ca21a) en clase-6 por generaci** nnn local de username con `Math.random`
- **#13, #14, # A20ade `clase-7` con autenticaci** nnn JWT (Express + bcrypt + cookie-parser + ejs)
  - Nombre del paquete corregido
 `Validation` corregido
  - Campo `_id` en `User.create` corregido
  - `console.log` de debug eliminado
  - Template `index.ejs` limpio con auto-login tras registro

Cierra: #6, #13, #14, #20, #21